### PR TITLE
유효하지 않은 도메인 때문에 ga 쿠키가 거부되는 이슈

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-%VITE_GA%', { cookie_flags: 'SameSite=None;Secure' });
+      gtag('config', 'G-%VITE_GA%', { cookie_domain: '%VITE_DOMAIN%',cookie_flags: 'SameSite=None;Secure' });
     </script>
     <meta charset="UTF-8" />
     <meta name="description" content="MZ세대들을 위한 논쟁 밸런스 게임 서비스😎" />


### PR DESCRIPTION
## 작업 내용
ga태그에 cookie_domain 설정
closes: #32 
## 주의 사항
